### PR TITLE
Fix comment typo in worker config

### DIFF
--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -4977,7 +4977,7 @@ declare module "cloudflare:pipelines" {
         protected ctx: ExecutionContext;
         constructor(ctx: ExecutionContext, env: Env);
         /**
-         * run recieves an array of PipelineRecord which can be
+         * run receives an array of PipelineRecord which can be
          * transformed and returned to the pipeline
          * @param records Incoming records from the pipeline to be transformed
          * @param metadata Information about the specific pipeline calling the transformation entrypoint


### PR DESCRIPTION
## Summary
- correct a typo in the worker configuration types file

## Testing
- `npm test` *(fails: Missing script "test" in frontend)*

------
https://chatgpt.com/codex/tasks/task_e_6840cfb422f88331bee19f3fe1bb3a94