### PR TITLE
feat(patient-portal): add online triage landing and 24/7 e-consultation page

### DIFF
--- a/frontend/patient-portal/src/pages/appointments.js
+++ b/frontend/patient-portal/src/pages/appointments.js
@@ -1,0 +1,72 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { Box, Container, Typography, Card, CardContent, List, ListItem, ListItemText, Button } from '@mui/material';
+
+const outcomes = [
+  'Urgent same-day appointment where clinically needed',
+  'Routine appointment booking with the right clinician',
+  'Referral to pharmacy or another suitable service',
+  'Self-care guidance and educational resources',
+  'Tests and investigations arranged when appropriate',
+];
+
+export default function AppointmentsPage() {
+  return (
+    <>
+      <Head>
+        <title>HealthLinc - Appointments & e-Consultations</title>
+        <meta
+          name="description"
+          content="Online e-consultations are available 24/7 and reviewed during core hours with clear triage outcomes."
+        />
+      </Head>
+
+      <Box className="min-h-screen bg-gray-50 py-12">
+        <Container maxWidth="md">
+          <Typography variant="h3" className="font-display font-bold mb-4">
+            Appointments and 24/7 e-Consultations
+          </Typography>
+          <Typography variant="body1" className="text-gray-700 mb-6">
+            You can submit an e-consultation request any time, day or night. Requests are clinically reviewed during
+            core opening hours, and you will be contacted with the most appropriate next step.
+          </Typography>
+
+          <Card className="mb-6">
+            <CardContent>
+              <Typography variant="h6" className="font-semibold mb-2">
+                Possible outcomes
+              </Typography>
+              <List dense>
+                {outcomes.map((item) => (
+                  <ListItem key={item} className="px-0">
+                    <ListItemText primary={item} />
+                  </ListItem>
+                ))}
+              </List>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent>
+              <Typography variant="h6" className="font-semibold mb-2">
+                Important safety guidance
+              </Typography>
+              <Typography variant="body2" color="text.secondary" className="mb-4">
+                If your issue is urgent, call the practice or NHS 111 instead of waiting for an online response.
+                For life-threatening emergencies, call 999 immediately.
+              </Typography>
+              <Box className="flex gap-3 flex-wrap">
+                <Link href="/" passHref>
+                  <Button variant="outlined">Back to Home</Button>
+                </Link>
+                <Button variant="contained" className="bg-primary-500 hover:bg-primary-600">
+                  Start Online Consultation
+                </Button>
+              </Box>
+            </CardContent>
+          </Card>
+        </Container>
+      </Box>
+    </>
+  );
+}

--- a/frontend/patient-portal/src/pages/index.js
+++ b/frontend/patient-portal/src/pages/index.js
@@ -2,168 +2,250 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Box, Button, Typography, Container } from '@mui/material';
+import {
+  Box,
+  Button,
+  Typography,
+  Container,
+  Card,
+  CardContent,
+  CardActions,
+  Chip,
+  MenuItem,
+  Select,
+  FormControl,
+  Alert,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+
+const consultationPlatforms = [
+  {
+    name: 'RapidHealth',
+    description:
+      'Access self-care information, submit medical and admin requests, and register as a new patient in one flow.',
+    cta: 'Open RapidHealth',
+    href: 'https://rapidhealth.co.uk/',
+  },
+  {
+    name: 'Patchs',
+    description:
+      'Complete a short request form so the team can review your need and route it to the right clinician or service.',
+    cta: 'Go to Patchs',
+    href: 'https://patchs.ai/',
+  },
+  {
+    name: 'Accurx',
+    description:
+      'Send structured online requests and receive secure updates from the practice without waiting on hold.',
+    cta: 'Use Accurx',
+    href: 'https://accurx.com/',
+  },
+  {
+    name: 'Klinik',
+    description:
+      'Submit symptoms online and get guided to urgent care, routine care, self-care, or onward referral.',
+    cta: 'Open Klinik',
+    href: 'https://klinik.co.uk/',
+  },
+  {
+    name: 'SystmConnect',
+    description:
+      'No need to call or queue. Share your request digitally and get contacted during core working hours.',
+    cta: 'Open SystmConnect',
+    href: 'https://systmonline.tpp-uk.com/',
+  },
+  {
+    name: 'Engage',
+    description:
+      'Use Engage for online admin requests, updates, and direct digital communication with your practice.',
+    cta: 'Open Engage',
+    href: 'https://engage.gp/',
+  },
+];
+
+const healthInformation = [
+  'Managing anxiety and stress support options',
+  'How specialist referrals are reviewed',
+  'Vitamin D prescribing guidance',
+  'Antibiotic resistance and safe usage advice',
+  'How to request repeat medication safely',
+  'When to contact a pharmacist first',
+];
+
+const practiceNews = [
+  'Target training date: 14 May 2026 (limited routine appointments during staff training).',
+  'Bank holiday opening schedule updated for urgent and non-urgent requests.',
+  'Community campaign launched on antibiotic resistance awareness.',
+];
+
+const languages = ['English', 'العربية', 'Français', 'Polski', 'Español', 'اردو'];
 
 export default function Home() {
   const router = useRouter();
-  
+
   useEffect(() => {
-    // Redirect to dashboard if already logged in
     const token = localStorage.getItem('healthlinc-auth-token');
     if (token) {
       router.push('/dashboard');
     }
   }, [router]);
-  
+
   return (
     <>
       <Head>
-        <title>HealthLinc - Patient Portal</title>
-        <meta name="description" content="Access your healthcare records, claims, and more with the HealthLinc patient portal." />
+        <title>HealthLinc - Online Triage & Booking</title>
+        <meta
+          name="description"
+          content="Use HealthLinc for online triage, 24/7 e-consultation requests, self-care guidance, and appointment booking."
+        />
       </Head>
-      
-      <Box 
-        component="main" 
-        className="min-h-screen flex flex-col bg-gradient-to-b from-white to-primary-50"
-      >
-        {/* Header */}
+
+      <Box component="main" className="min-h-screen flex flex-col bg-gradient-to-b from-white to-primary-50">
         <Box className="bg-white shadow-sm">
           <Container maxWidth="lg">
             <Box className="flex justify-between items-center py-4">
               <Typography variant="h5" component="h1" className="font-display font-bold text-primary-600">
                 HealthLinc
               </Typography>
-              
-              <Link href="/login" passHref>
-                <Button 
-                  variant="contained" 
-                  color="primary" 
-                  className="bg-primary-500 hover:bg-primary-600"
-                >
-                  Sign In
-                </Button>
-              </Link>
-            </Box>
-          </Container>
-        </Box>
-        
-        {/* Hero section */}
-        <Container maxWidth="lg" className="flex-grow flex items-center">
-          <Box className="grid md:grid-cols-2 gap-12 py-12">
-            <Box className="flex flex-col justify-center">
-              <Typography 
-                variant="h2" 
-                component="h2" 
-                className="font-display font-bold text-gray-900 mb-6"
-                sx={{ 
-                  fontSize: { xs: '2.5rem', md: '3.5rem' },
-                  lineHeight: 1.2
-                }}
-              >
-                Your Health Records & Claims in One Place
-              </Typography>
-              
-              <Typography variant="body1" className="text-gray-700 text-lg mb-8">
-                Access your medical records, track insurance claims, and communicate with your healthcare providers securely through our patient portal.
-              </Typography>
-              
-              <Box className="flex flex-col sm:flex-row gap-4">
+
+              <Box className="flex gap-3">
+                <Link href="/appointments" passHref>
+                  <Button variant="outlined" color="primary">
+                    Appointments
+                  </Button>
+                </Link>
                 <Link href="/login" passHref>
-                  <Button 
-                    variant="contained" 
-                    color="primary" 
-                    size="large"
-                    className="bg-primary-500 hover:bg-primary-600 py-3 px-8"
-                  >
+                  <Button variant="contained" color="primary" className="bg-primary-500 hover:bg-primary-600">
                     Sign In
                   </Button>
                 </Link>
-                
-                <Button 
-                  variant="outlined" 
-                  size="large"
-                  className="border-primary-500 text-primary-500 hover:bg-primary-50 py-3 px-8"
-                >
-                  Learn More
-                </Button>
-              </Box>
-            </Box>
-            
-            <Box className="flex items-center justify-center">
-              {/* Replace with actual image */}
-              <Box className="w-full h-96 bg-white rounded-lg shadow-lg overflow-hidden">
-                <div className="w-full h-full bg-gradient-to-br from-primary-100 to-secondary-100 flex items-center justify-center">
-                  <Typography variant="h3" className="text-primary-700 font-display font-medium">
-                    Portal Image
-                  </Typography>
-                </div>
-              </Box>
-            </Box>
-          </Box>
-        </Container>
-        
-        {/* Features section */}
-        <Box className="bg-white py-16">
-          <Container maxWidth="lg">
-            <Typography variant="h3" component="h3" className="text-center font-display font-bold mb-12">
-              Key Features
-            </Typography>
-            
-            <Box className="grid md:grid-cols-3 gap-8">
-              <Box className="p-6 bg-primary-50 rounded-lg">
-                <Typography variant="h5" className="font-medium mb-3">
-                  Claims Management
-                </Typography>
-                <Typography variant="body1" color="text.secondary">
-                  Track your insurance claims in real time. View status, payments, and resolve issues quickly.
-                </Typography>
-              </Box>
-              
-              <Box className="p-6 bg-primary-50 rounded-lg">
-                <Typography variant="h5" className="font-medium mb-3">
-                  Medical Records
-                </Typography>
-                <Typography variant="body1" color="text.secondary">
-                  Access your complete medical history, test results, and treatment plans securely.
-                </Typography>
-              </Box>
-              
-              <Box className="p-6 bg-primary-50 rounded-lg">
-                <Typography variant="h5" className="font-medium mb-3">
-                  Provider Communication
-                </Typography>
-                <Typography variant="body1" color="text.secondary">
-                  Message your healthcare team, request appointments, and get answers to your questions.
-                </Typography>
               </Box>
             </Box>
           </Container>
         </Box>
-        
-        {/* Footer */}
-        <Box className="bg-gray-900 text-white py-8">
-          <Container maxWidth="lg">
-            <Box className="flex flex-col md:flex-row justify-between items-center">
-              <Typography variant="body2" className="mb-4 md:mb-0">
-                &copy; 2025 HealthLinc. All rights reserved.
+
+        <Container maxWidth="lg" className="py-12">
+          <Alert severity="info" className="mb-6">
+            Need urgent help? Call <strong>NHS 111</strong> for non-emergency urgent guidance, available 24/7.
+          </Alert>
+
+          <Box className="grid md:grid-cols-2 gap-8 items-center mb-10">
+            <Box>
+              <Typography variant="h3" component="h2" className="font-display font-bold text-gray-900 mb-4">
+                Online Triage and Appointment Booking
               </Typography>
-              
-              <Box className="flex gap-6">
+              <Typography variant="body1" className="text-gray-700 text-lg mb-6">
+                Tell us what you need by answering a few quick questions. We triage requests into urgent care,
+                routine care, pharmacy support, self-care advice, or follow-up tests.
+              </Typography>
+              <Box className="flex gap-3 flex-wrap">
+                <Link href="/appointments" passHref>
+                  <Button variant="contained" size="large" className="bg-primary-500 hover:bg-primary-600">
+                    Start e-Consultation
+                  </Button>
+                </Link>
+                <Button variant="outlined" size="large">
+                  Learn About Self-Care
+                </Button>
+              </Box>
+            </Box>
+            <Box className="bg-white rounded-lg shadow-lg p-6">
+              <Typography variant="h6" className="mb-3 font-semibold">
+                Triage outcomes you can expect
+              </Typography>
+              <List dense>
+                {['Urgent appointment', 'Routine appointment', 'Pharmacy referral', 'Self-care information', 'Organised tests'].map((item) => (
+                  <ListItem key={item} className="px-0">
+                    <ListItemText primary={item} />
+                  </ListItem>
+                ))}
+              </List>
+              <Chip label="Reviewed during core hours" color="primary" variant="outlined" />
+            </Box>
+          </Box>
+
+          <Typography variant="h4" className="font-display font-bold mb-6">
+            Online Consultation Systems
+          </Typography>
+          <Box className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
+            {consultationPlatforms.map((platform) => (
+              <Card key={platform.name} className="h-full flex flex-col">
+                <CardContent className="flex-grow">
+                  <Typography variant="h6" className="font-semibold mb-2">
+                    {platform.name}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {platform.description}
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button size="small" href={platform.href} target="_blank" rel="noopener noreferrer">
+                    {platform.cta}
+                  </Button>
+                </CardActions>
+              </Card>
+            ))}
+          </Box>
+
+          <Box className="grid md:grid-cols-2 gap-8 mb-12">
+            <Box className="bg-white p-6 rounded-lg shadow-sm">
+              <Typography variant="h5" className="mb-3 font-semibold">
+                Health Information
+              </Typography>
+              <Typography variant="body2" color="text.secondary" className="mb-2">
+                Explore trusted self-care resources before booking or calling.
+              </Typography>
+              <List dense>
+                {healthInformation.map((topic) => (
+                  <ListItem key={topic} className="px-0">
+                    <ListItemText primary={topic} />
+                  </ListItem>
+                ))}
+              </List>
+            </Box>
+
+            <Box className="bg-white p-6 rounded-lg shadow-sm">
+              <Typography variant="h5" className="mb-3 font-semibold">
+                Practice News
+              </Typography>
+              <List dense>
+                {practiceNews.map((news) => (
+                  <ListItem key={news} className="px-0">
+                    <ListItemText primary={news} />
+                  </ListItem>
+                ))}
+              </List>
+            </Box>
+          </Box>
+        </Container>
+
+        <Box className="bg-gray-900 text-white py-8 mt-auto">
+          <Container maxWidth="lg">
+            <Box className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+              <Typography variant="body2">&copy; 2026 HealthLinc. All rights reserved.</Typography>
+
+              <Box className="flex flex-wrap gap-4 items-center">
                 <Link href="/privacy" passHref>
                   <Typography variant="body2" className="text-gray-300 hover:text-white">
                     Privacy Policy
                   </Typography>
                 </Link>
-                <Link href="/terms" passHref>
+                <Link href="/accessibility" passHref>
                   <Typography variant="body2" className="text-gray-300 hover:text-white">
-                    Terms of Service
+                    Accessibility
                   </Typography>
                 </Link>
-                <Link href="/contact" passHref>
-                  <Typography variant="body2" className="text-gray-300 hover:text-white">
-                    Contact Us
-                  </Typography>
-                </Link>
+                <FormControl size="small" sx={{ minWidth: 150, backgroundColor: 'white', borderRadius: 1 }}>
+                  <Select defaultValue="English" aria-label="Language selector">
+                    {languages.map((language) => (
+                      <MenuItem key={language} value={language}>
+                        {language}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
               </Box>
             </Box>
           </Container>


### PR DESCRIPTION
### **User description**
### Motivation
- Rework the patient-portal home to present an online triage and booking experience consistent with modern NHS practice sites and the product brief. 
- Surface external online consultation systems, self-care resources and multilingual support so patients can self-serve before contacting staff. 
- Provide a clear, standalone page describing 24/7 e-consultation availability and expected triage outcomes for transparency and safer routing.

### Description
- Updated `frontend/patient-portal/src/pages/index.js` to redesign the home/landing content with triage guidance, an NHS 111 alert, triage outcome messaging, a grid of consultation platform cards (RapidHealth, Patchs, Accurx, Klinik, SystmConnect, Engage), health information list, practice news area, and a footer language selector. 
- Added `frontend/patient-portal/src/pages/appointments.js` which describes 24/7 e-consultation availability, lists possible triage outcomes, and includes safety guidance and CTA buttons. 
- UI/content-only changes with no backend, API, or data-model modifications. 
- Changes were committed on the working branch and prepared as a PR titled `feat: add patient-portal online triage and 24/7 e-consultation experience`.

### Testing
- Ran `npm --prefix frontend/patient-portal install` successfully to install dependencies. 
- Attempted `npm --prefix frontend/patient-portal run lint` which launched Next.js ESLint interactive setup and could not complete non-interactively in this environment. 
- Ran `npm --prefix frontend/patient-portal run build` which failed due to pre-existing project issues: Next.js reported a custom PostCSS config that does not export a `plugins` key and unresolved `@/...` alias imports in other existing pages. 
- Launched the dev server with `npm --prefix frontend/patient-portal run dev` and captured a full-page screenshot of the updated home at `http://localhost:3100` to validate the UI render locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2004dde508331bf635e45b17f8d9e)


___

### **PR Type**
Enhancement


___

### **Description**
- Redesigned home page with online triage guidance and NHS 111 alert

- Added 24/7 e-consultation page describing triage outcomes and safety guidance

- Integrated six external consultation platform cards (RapidHealth, Patchs, Accurx, Klinik, SystmConnect, Engage)

- Added health information resources, practice news section, and multilingual footer language selector


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Home Page"] -->|"Redesigned with triage guidance"| B["Online Triage Section"]
  A -->|"NHS 111 Alert"| C["Urgent Care Info"]
  A -->|"Grid of 6 platforms"| D["Consultation Systems"]
  A -->|"Self-care & news"| E["Health Resources"]
  A -->|"Language support"| F["Footer Selector"]
  G["New Appointments Page"] -->|"24/7 e-consultation details"| H["Triage Outcomes"]
  G -->|"Safety guidance"| I["Emergency Instructions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Redesign home page for online triage and booking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/patient-portal/src/pages/index.js

<ul><li>Replaced hero section with online triage and appointment booking <br>messaging<br> <li> Added NHS 111 alert banner for urgent care guidance<br> <li> Integrated grid of six external consultation platform cards with <br>descriptions and CTAs<br> <li> Added health information list covering self-care topics and practice <br>news section<br> <li> Replaced features section with triage outcomes list in sidebar card<br> <li> Added multilingual language selector dropdown in footer<br> <li> Updated page title and meta description to reflect triage focus<br> <li> Added navigation link to new appointments page in header</ul>


</details>


  </td>
  <td><a href="https://github.com/Fadil369/HealthLinc/pull/88/files#diff-cdb85df9221ed8020407071fb2487104e639ec3c3854b77b5143cd1da9348c2c">+202/-120</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>appointments.js</strong><dd><code>Create 24/7 e-consultation information page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/patient-portal/src/pages/appointments.js

<ul><li>Created new page describing 24/7 e-consultation availability and <br>review process<br> <li> Listed five possible triage outcomes (urgent appointment, routine <br>appointment, pharmacy referral, self-care guidance, tests)<br> <li> Added safety guidance section with emergency contact instructions<br> <li> Included CTA buttons for starting online consultation and returning to <br>home<br> <li> Set up proper Next.js Head metadata for SEO</ul>


</details>


  </td>
  <td><a href="https://github.com/Fadil369/HealthLinc/pull/88/files#diff-ff3aad6b6387a48de6adab50ffd52db06d87db862f492b467258747380c3a4ad">+72/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

